### PR TITLE
fix: copy yarn directory from nodejs image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
           tags: ruby-node-alpine:${{ matrix.ruby_version }}-${{ matrix.node_version }}-alpine
 
       - name: Test image
-        run: docker run -i ruby-node-alpine:${{ matrix.ruby_version }}-${{ matrix.node_version }}-alpine /bin/sh -c "ruby --version && node --version"
+        run: |
+          docker run -i ruby-node-alpine:${{ matrix.ruby_version }}-${{ matrix.node_version }}-alpine \
+            /bin/sh -c "ruby --version && node --version && yarn --version"
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,4 @@ COPY --from=node /usr/local/share /usr/local/share
 COPY --from=node /usr/local/lib /usr/local/lib
 COPY --from=node /usr/local/include /usr/local/include
 COPY --from=node /usr/local/bin /usr/local/bin
+COPY --from=node /opt /opt

--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ export RUBY_VERSION=3.0.3
 export NODE_VERSION=16.13.0
 docker build . --build-arg RUBY_VERSION=$RUBY_VERSION --build-arg NODE_VERSION=$NODE_VERSION --tag ruby-node-alpine:$RUBY_VERSION-$NODE_VERSION
 
-docker run --rm ruby-node-alpine:$RUBY_VERSION-$NODE_VERSION /bin/sh -c "ruby --version && node --version"
+docker run --rm ruby-node-alpine:$RUBY_VERSION-$NODE_VERSION /bin/sh -c "ruby --version && node --version && yarn --version"
 ```


### PR DESCRIPTION
Yarn binary is a symlink to a directory in `/opt`. Copying that directory as well will fix yarn in these images.

Fixes #1 